### PR TITLE
gps.ino - Also turn off RMC as it is not used

### DIFF
--- a/FlexTrack/gps.ino
+++ b/FlexTrack/gps.ino
@@ -203,6 +203,10 @@ void ProcessNMEA(char *Buffer, int Count)
     {
       DisableNMEAProtocol(5);
     }
+    else if (strncmp((char *)Buffer+3, "RMC", 3) == 0)
+    {
+      DisableNMEAProtocol(4);
+    }
   }
   else
   {


### PR DESCRIPTION
Not a critical change, but as we turn everything else except GGA off, adding turning RMC off too.